### PR TITLE
Add legacy.yml

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,0 +1,9 @@
+---
+Name: cmslegacy
+---
+SilverStripe\ORM\DatabaseAdmin:
+  classname_value_remapping:
+    RedirectUrl: 'Heyday\SilverStripeRedirects\Code\RedirectUrl'
+
+Heyday\SilverStripeRedirects\Code\RedirectUrl:
+  table_name: RedirectUrl

--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,5 +1,5 @@
 ---
-Name: cmslegacy
+Name: redirectslegacy
 ---
 SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:


### PR DESCRIPTION
For sites that have been upgraded from SilverStripe 3, this will mean that they can continue to edit redirects which had an incorrect class name.